### PR TITLE
Upgrade to FAB v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules/
 /dist/
 /yarn-error.log
-.fab/
 /fab.zip
 /fab/
 /.fab

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .fab/
 /fab.zip
 /fab/
+/.fab

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .fab
 fab
+node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@ node_modules
 dist
 .fab
 fab
-node_modules

--- a/fab.config.json5
+++ b/fab.config.json5
@@ -1,0 +1,29 @@
+// For more information, see https://fab.dev/kb/configuration
+{
+  plugins: {
+    "@fab/input-static": {
+      dir: "dist",
+    },
+    "@fab/plugin-render-html": {
+      fallback: "/index.html",
+    },
+    "@fab/plugin-rewire-assets": {},
+    // This section defines your build & runtime toolchains. See https://fab.dev/kb/plugins
+  },
+  settings: {
+    // This section defines the variables that are injected, depending on environment.
+    // See https://fab.dev/kb/settings for more info.
+    production: {
+      // This environment is special. These variables get compiled into the FAB itself,
+      // allowing for many production-specific optimisations. See https://fab.dev/kb/production
+      // Example setting:
+      // API_URL: 'https://api.example.com/graphql'
+    },
+  },
+  deploy: {
+    // For manual (command-line) deploys, add configuration here.
+    // • See https://fab.dev/kb/deploying for more info.
+    // For automatic deploys (triggered by git push), we recommend using Linc:
+    // • See https://linc.sh/docs/automatic-deploys for setup instructions.
+  },
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "index.js",
   "scripts": {
     "start": "NODE_ENV=development webpack-dev-server --no-inline",
-    "build:fab": "npm run build",
-    "build": "NODE_ENV=production webpack && fab-static dist",
+    "build:fab": "npm run build && npm run fab:build",
+    "build": "NODE_ENV=production webpack",
+    "fab:build": "fab build",
+    "fab:serve": "fab serve fab.zip",
     "serve": "fab-serve fab.zip",
     "lint.eslint": "eslint .",
     "lint.prettier": "prettier --list-different .",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "NODE_ENV=production webpack",
     "fab:build": "fab build",
     "fab:serve": "fab serve fab.zip",
-    "serve": "fab-serve fab.zip",
+    "serve": "npm run fab:serve",
     "lint.eslint": "eslint .",
     "lint.prettier": "prettier --list-different .",
     "lint.tslint": "tslint -c tslint.json --project tsconfig.json",


### PR DESCRIPTION
Upgrading to the latest FAB v1.0. The API is significantly different as well as dependencies but the bulk of the work was done by running `npx fab init`.